### PR TITLE
add default value to athlete's state

### DIFF
--- a/Sources/Athlete.swift
+++ b/Sources/Athlete.swift
@@ -78,7 +78,7 @@ public struct Athlete {
             let firstName: String = s.value("firstname"),
             let lastName: String = s.value("lastname"),
             let city: String = s.value("city"),
-            let state: String = s.value("state"),
+            let state: String = s.value("state", required: false, nilValue: ""),
             let country: String = s.value("country"),
             let profile: String = s.value("profile"),
             let profileImageURL = URL(string: profile),


### PR DESCRIPTION
I have realized that state can be `null` for people living outside USA. This was causing integration test to fail and also crashing Demo App. Alternative approach will be to make it optional.
